### PR TITLE
Fix: absolute paths in xml doc

### DIFF
--- a/src/softaware.Cqs.Decorators.FluentValidation/softaware.Cqs.Decorators.FluentValidation.csproj
+++ b/src/softaware.Cqs.Decorators.FluentValidation/softaware.Cqs.Decorators.FluentValidation.csproj
@@ -24,11 +24,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>C:\Development\softaware\library-cqs\src\softaware.Cqs.Decorators.FluentValidation\softaware.Cqs.Decorators.FluentValidation.xml</DocumentationFile>
+    <DocumentationFile>softaware.Cqs.Decorators.FluentValidation.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\Development\softaware\library-cqs\src\softaware.Cqs.Decorators.FluentValidation\softaware.Cqs.Decorators.FluentValidation.xml</DocumentationFile>
+    <DocumentationFile>softaware.Cqs.Decorators.FluentValidation.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/softaware.Cqs.Decorators.Transaction/softaware.Cqs.Decorators.Transaction.csproj
+++ b/src/softaware.Cqs.Decorators.Transaction/softaware.Cqs.Decorators.Transaction.csproj
@@ -22,11 +22,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>C:\Development\library-cqs\src\softaware.Cqs.Decorators.Transaction\softaware.Cqs.Decorators.Transaction.xml</DocumentationFile>
+    <DocumentationFile>softaware.Cqs.Decorators.Transaction.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\Development\library-cqs\src\softaware.Cqs.Decorators.Transaction\softaware.Cqs.Decorators.Transaction.xml</DocumentationFile>
+    <DocumentationFile>softaware.Cqs.Decorators.Transaction.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/softaware.Cqs.Decorators.UsageAware/softaware.Cqs.Decorators.UsageAware.csproj
+++ b/src/softaware.Cqs.Decorators.UsageAware/softaware.Cqs.Decorators.UsageAware.csproj
@@ -22,11 +22,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>C:\Development\library-cqs\src\softaware.Cqs.Decorators.UsageAware\softaware.Cqs.Decorators.UsageAware.xml</DocumentationFile>
+    <DocumentationFile>softaware.Cqs.Decorators.UsageAware.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\Development\library-cqs\src\softaware.Cqs.Decorators.UsageAware\softaware.Cqs.Decorators.UsageAware.xml</DocumentationFile>
+    <DocumentationFile>softaware.Cqs.Decorators.UsageAware.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/softaware.Cqs.Decorators.Validation/softaware.Cqs.Decorators.Validation.csproj
+++ b/src/softaware.Cqs.Decorators.Validation/softaware.Cqs.Decorators.Validation.csproj
@@ -23,11 +23,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>C:\Development\library-cqs\src\softaware.Cqs.Decorators.Validation\softaware.Cqs.Decorators.Validation.xml</DocumentationFile>
+    <DocumentationFile>softaware.Cqs.Decorators.Validation.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\Development\library-cqs\src\softaware.Cqs.Decorators.Validation\softaware.Cqs.Decorators.Validation.xml</DocumentationFile>
+    <DocumentationFile>softaware.Cqs.Decorators.Validation.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/softaware.Cqs.SimpleInjector/softaware.Cqs.SimpleInjector.csproj
+++ b/src/softaware.Cqs.SimpleInjector/softaware.Cqs.SimpleInjector.csproj
@@ -22,11 +22,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>C:\Development\library-cqs\src\softaware.Cqs.SimpleInjector\softaware.Cqs.SimpleInjector.xml</DocumentationFile>
+    <DocumentationFile>softaware.Cqs.SimpleInjector.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\Development\library-cqs\src\softaware.Cqs.SimpleInjector\softaware.Cqs.SimpleInjector.xml</DocumentationFile>
+    <DocumentationFile>softaware.Cqs.SimpleInjector.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/softaware.Cqs/softaware.Cqs.csproj
+++ b/src/softaware.Cqs/softaware.Cqs.csproj
@@ -24,11 +24,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>C:\Development\library-cqs\src\softaware.Cqs\softaware.Cqs.xml</DocumentationFile>
+    <DocumentationFile>softaware.Cqs.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\Development\library-cqs\src\softaware.Cqs\softaware.Cqs.xml</DocumentationFile>
+    <DocumentationFile>softaware.Cqs.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
❌ **Problem**
Paths for xml documentation generation is specified in absolute paths, so it won't work on different machines.

✔️ **Fix**
Changed them to relative ones. 🥳 