### PR TITLE
Fix exception in DI registration when one RequestHandler implements multiple IRequestHandler<T, R> interfaces

### DIFF
--- a/src/softaware.Cqs.DependencyInjection/RequestHandlerTypeHelper.cs
+++ b/src/softaware.Cqs.DependencyInjection/RequestHandlerTypeHelper.cs
@@ -5,7 +5,7 @@ internal static class RequestHandlerTypeHelper
     public static readonly Type GenericRequestHandlerTypeDefinition = typeof(IRequestHandler<,>);
 
     /// <summary>
-    /// Tries to find the <see cref="IRequestHandler{TRequest, TResult}"/> interface with
+    /// Tries to find the <see cref="IRequestHandler{TRequest, TResult}"/> interfaces with
     /// type arguments the provided <paramref name="type"/> implements.
     /// The type arguments can either be concrete types, type arguments of the provided
     /// <paramref name="type"/>, or a combination - which is currently not supported):
@@ -18,7 +18,7 @@ internal static class RequestHandlerTypeHelper
     ///                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     /// </code>
     /// </summary>
-    /// <param name="type">The type to search for the <see cref="IRequestHandler{TRequest, TResult}"/> interface.</param>
+    /// <param name="type">The type to search for the <see cref="IRequestHandler{TRequest, TResult}"/> interfaces.</param>
     /// <returns>The implemented <see cref="IRequestHandler{TRequest, TResult}"/> interface types
     /// with type arguments. Can be empty if none is found.</returns>
     public static IEnumerable<Type> GetImplementedRequestHandlerInterfaceTypes(this Type type)

--- a/src/softaware.Cqs.DependencyInjection/SoftawareCqsExtensions.cs
+++ b/src/softaware.Cqs.DependencyInjection/SoftawareCqsExtensions.cs
@@ -25,7 +25,7 @@ public static class SoftawareCqsExtensions
             .Scan(scan => scan
                 .FromAssemblies(typesBuilder.RegisteredAssemblies)
                 .AddClasses(classes => classes.AssignableTo(typeof(IRequestHandler<,>))
-                                              .Where(t => !t.IsDecorator()))
+                                              .Where(t => !t.GetDecoratorInfo().IsDecorator))
                 .AsImplementedInterfaces()
                 .WithTransientLifetime());
 

--- a/src/softaware.Cqs.DependencyInjection/softaware.Cqs.DependencyInjection.csproj
+++ b/src/softaware.Cqs.DependencyInjection/softaware.Cqs.DependencyInjection.csproj
@@ -13,15 +13,15 @@
 		<RepositoryType>git</RepositoryType>
 		<PackageProjectUrl>https://github.com/softawaregmbh/library-cqs</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/softawaregmbh/library-cqs</RepositoryUrl>
-		<Version>4.0.0</Version>
+		<Version>4.0.1</Version>
 		<PackageId>softaware.CQS.DependencyInjection</PackageId>
 		<PackageIcon>package-icon.png</PackageIcon>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-		<FileVersion>4.0.0.0</FileVersion>
-		<AssemblyVersion>4.0.0.0</AssemblyVersion>
+		<FileVersion>4.0.1.0</FileVersion>
+		<AssemblyVersion>4.0.1.0</AssemblyVersion>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
 

--- a/src/softaware.Cqs.Tests/CQ.Contract/Queries/SimpleQuery1.cs
+++ b/src/softaware.Cqs.Tests/CQ.Contract/Queries/SimpleQuery1.cs
@@ -1,0 +1,4 @@
+namespace softaware.Cqs.Tests.CQ.Contract.Queries;
+public class SimpleQuery1 : IQuery<string>
+{
+}

--- a/src/softaware.Cqs.Tests/CQ.Contract/Queries/SimpleQuery2.cs
+++ b/src/softaware.Cqs.Tests/CQ.Contract/Queries/SimpleQuery2.cs
@@ -1,0 +1,4 @@
+namespace softaware.Cqs.Tests.CQ.Contract.Queries;
+internal class SimpleQuery2 : IQuery<string>
+{
+}

--- a/src/softaware.Cqs.Tests/CQ.Handlers/QueryHandlers/SimpleQueryHandler.cs
+++ b/src/softaware.Cqs.Tests/CQ.Handlers/QueryHandlers/SimpleQueryHandler.cs
@@ -1,0 +1,10 @@
+using softaware.Cqs.Tests.CQ.Contract.Queries;
+
+namespace softaware.Cqs.Tests.CQ.Handlers.QueryHandlers;
+internal class SimpleQueryHandler
+    : IRequestHandler<SimpleQuery1, string>,
+    IRequestHandler<SimpleQuery2, string>
+{
+    public Task<string> HandleAsync(SimpleQuery1 request, CancellationToken cancellationToken) => Task.FromResult("Simple Query 1 Result");
+    public Task<string> HandleAsync(SimpleQuery2 request, CancellationToken cancellationToken) => Task.FromResult("Simple Query 2 Result");
+}

--- a/src/softaware.Cqs.Tests/Decorators/InvalidDecoratorWithoutGenericArgumentsMultipleRequestHandlers.cs
+++ b/src/softaware.Cqs.Tests/Decorators/InvalidDecoratorWithoutGenericArgumentsMultipleRequestHandlers.cs
@@ -1,0 +1,30 @@
+using softaware.Cqs.Tests.CQ.Contract.Commands;
+
+namespace softaware.Cqs.Tests.Decorators;
+
+public class InvalidDecoratorWithoutGenericArgumentsMultipleRequestHandlers
+    : IRequestHandler<SimpleCommand, NoResult>,
+    IRequestHandler<CommandWithResult, Guid>
+{
+    private readonly IRequestHandler<SimpleCommand, NoResult> simpleCommandDecoratee;
+    private readonly IRequestHandler<CommandWithResult, Guid> commandWithResultDecoratee;
+
+    public InvalidDecoratorWithoutGenericArgumentsMultipleRequestHandlers(
+        IRequestHandler<SimpleCommand, NoResult> simpleCommandDecoratee,
+        IRequestHandler<CommandWithResult, Guid> commandWithResultDecoratee)
+    {
+        this.simpleCommandDecoratee = simpleCommandDecoratee ?? throw new ArgumentNullException(nameof(simpleCommandDecoratee));
+        this.commandWithResultDecoratee = commandWithResultDecoratee ?? throw new ArgumentNullException(nameof(commandWithResultDecoratee));
+    }
+
+    public async Task<NoResult> HandleAsync(SimpleCommand request, CancellationToken cancellationToken)
+    {
+        request.Value++;
+        return await this.simpleCommandDecoratee.HandleAsync(request, cancellationToken);
+    }
+
+    public async Task<Guid> HandleAsync(CommandWithResult request, CancellationToken cancellationToken)
+    {
+        return await this.commandWithResultDecoratee.HandleAsync(request, cancellationToken);
+    }
+}

--- a/src/softaware.Cqs.Tests/GenericTypeArgumentDecoratorTest.cs
+++ b/src/softaware.Cqs.Tests/GenericTypeArgumentDecoratorTest.cs
@@ -124,6 +124,23 @@ public class GenericTypeArgumentDecoratorSimpleInjectorTests
 
         Assert.AreEqual(2, command.Value);
     }
+
+    [Test]
+    public void InvalidDecoratorWithoutGenericArgumentsMultipleRequestHandlers_Throws()
+    {
+        var container = new Container();
+
+        container
+            .AddSoftawareCqs(b => b.IncludeTypesFrom(Assembly.GetExecutingAssembly()))
+            .AddDecorators(b => b
+                .AddRequestHandlerDecorator(typeof(InvalidDecoratorWithoutGenericArgumentsMultipleRequestHandlers)));
+
+        container.Register<IDependency, Dependency>();
+
+        var exception = Assert.Throws<InvalidOperationException>(container.Verify);
+
+        Assert.AreEqual("The configuration is invalid. Creating the instance for type IRequestHandler<CommandWithResult, Guid> failed. The configuration is invalid. The type CommandWithResultHandler is directly or indirectly depending on itself. The cyclic graph contains the following types: InvalidDecoratorWithoutGenericArgumentsMultipleRequestHandlers -> InvalidDecoratorWithoutGenericArgumentsMultipleRequestHandlers -> CommandWithResultHandler.", exception!.Message);
+    }
 }
 
 [TestFixture]
@@ -256,5 +273,18 @@ Alternatively, you can use softaware.CQS.SimpleInjector instead of softaware.CQS
         await requestProcessor.HandleAsync(command, default);
 
         Assert.AreEqual(2, command.Value);
+    }
+
+    [Test]
+    public void InvalidDecoratorWithoutGenericArgumentsMultipleRequestHandlers_Throws()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Assert.Throws<ArgumentException>(() => services
+            .AddSoftawareCqs(b => b.IncludeTypesFrom(Assembly.GetExecutingAssembly()))
+            .AddDecorators(b => b
+                .AddRequestHandlerDecorator(typeof(InvalidDecoratorWithoutGenericArgumentsMultipleRequestHandlers))));
+
+        Assert.AreEqual("Type 'softaware.Cqs.Tests.Decorators.InvalidDecoratorWithoutGenericArgumentsMultipleRequestHandlers' cannot be used as decorator for ['softaware.Cqs.IRequestHandler`2[softaware.Cqs.Tests.CQ.Contract.Commands.SimpleCommand,softaware.Cqs.NoResult]', 'softaware.Cqs.IRequestHandler`2[softaware.Cqs.Tests.CQ.Contract.Commands.CommandWithResult,System.Guid]'] because it is not supported that decorators implement multiple IRequestHandler<TRequest, TResult> interfaces. (Parameter 'decoratorType')", exception!.Message);
     }
 }

--- a/src/softaware.Cqs.Tests/RequestProcessorTest.cs
+++ b/src/softaware.Cqs.Tests/RequestProcessorTest.cs
@@ -32,6 +32,19 @@ public abstract class RequestProcessorTest : TestBase
     }
 
     [Test]
+    public async Task ExecuteSimpleQueriesInSameHandler()
+    {
+        var query1 = new SimpleQuery1();
+        var query2 = new SimpleQuery2();
+
+        var result1 = await this.requestProcessor.HandleAsync(query1, default);
+        var result2 = await this.requestProcessor.HandleAsync(query2, default);
+
+        Assert.That(result1, Is.EqualTo("Simple Query 1 Result"));
+        Assert.That(result2, Is.EqualTo("Simple Query 2 Result"));
+    }
+
+    [Test]
     public abstract Task ExecuteCommandWithDependency();
 
     private abstract class SimpleInjectorTest


### PR DESCRIPTION
* This PR fixes an exeption in MS.DI when one concrete `RequestHandler` implements multiple `IRequestHandler<T, R>` interfaces.
* It explicitly adds assertions and tests that we don't support decorators which implement multiple `IRequestHandler<T, R>` interfaces.