### PR TITLE
fix: register handlers that inject other request handlers

### DIFF
--- a/src/softaware.Cqs.DependencyInjection.SourceGenerated/softaware.Cqs.DependencyInjection.SourceGenerated.csproj
+++ b/src/softaware.Cqs.DependencyInjection.SourceGenerated/softaware.Cqs.DependencyInjection.SourceGenerated.csproj
@@ -14,15 +14,15 @@
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/softawaregmbh/library-cqs</PackageProjectUrl>
     <RepositoryUrl>https://github.com/softawaregmbh/library-cqs</RepositoryUrl>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <PackageId>softaware.CQS.DependencyInjection.SourceGenerated</PackageId>
     <PackageIcon>package-icon.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <FileVersion>1.0.0.0</FileVersion>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.1.0</FileVersion>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <RootNamespace>softaware.Cqs.DependencyInjection.SourceGenerated</RootNamespace>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>

--- a/src/softaware.Cqs.DependencyInjection.SourceGenerator.Tests/CqsSourceGeneratorTests.cs
+++ b/src/softaware.Cqs.DependencyInjection.SourceGenerator.Tests/CqsSourceGeneratorTests.cs
@@ -46,6 +46,57 @@ public class Startup
     }
 
     [Fact]
+    public void HandlerInjectingAnotherHandler_IsRegisteredAndNotTreatedAsDecorator()
+    {
+        var source = @"
+using softaware.Cqs;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TestApp;
+
+public class GetInner : IQuery<int>
+{
+}
+
+public class GetInnerHandler : IRequestHandler<GetInner, int>
+{
+    public System.Threading.Tasks.Task<int> HandleAsync(GetInner query, System.Threading.CancellationToken ct)
+        => System.Threading.Tasks.Task.FromResult(42);
+}
+
+public class GetOuter : IQuery<int>
+{
+}
+
+// Composing handler: injects a *different* IRequestHandler. Must NOT be treated as a decorator.
+public class GetOuterHandler : IRequestHandler<GetOuter, int>
+{
+    private readonly IRequestHandler<GetInner, int> inner;
+    public GetOuterHandler(IRequestHandler<GetInner, int> inner) => this.inner = inner;
+
+    public System.Threading.Tasks.Task<int> HandleAsync(GetOuter query, System.Threading.CancellationToken ct)
+        => this.inner.HandleAsync(new GetInner(), ct);
+}
+
+public class Startup
+{
+    public void Configure(IServiceCollection services)
+    {
+        services.AddSoftawareCqs(b => b.IncludeTypesFrom(typeof(GetInner)));
+    }
+}
+";
+
+        var (outputCompilation, diagnostics, runResult) = TestHelper.RunGeneratorWithCompilation(source);
+
+        var registrationSource = TestHelper.GetGeneratedSource(runResult, "CqsServiceRegistration.g.cs");
+
+        Assert.NotNull(registrationSource);
+        Assert.Contains("GetOuterHandler", registrationSource);
+        Assert.Contains("GetInnerHandler", registrationSource);
+    }
+
+    [Fact]
     public void CommandHandler_GeneratesRegistration()
     {
         var source = @"

--- a/src/softaware.Cqs.DependencyInjection.SourceGenerator/CqsSourceGenerator.cs
+++ b/src/softaware.Cqs.DependencyInjection.SourceGenerator/CqsSourceGenerator.cs
@@ -551,13 +551,27 @@ public class CqsSourceGenerator : IIncrementalGenerator
 
     private static bool IsDecorator(INamedTypeSymbol type, INamedTypeSymbol requestHandlerType)
     {
+        // A decorator implements IRequestHandler<TRequest, TResult> and wraps the *same*
+        // IRequestHandler<TRequest, TResult> injected via its constructor (the inner handler).
+        // A regular handler may also inject *other* request handlers (composition) - those must
+        // NOT be treated as decorators, otherwise they would be excluded from registration.
+        var implementedHandlerInterfaces = type.AllInterfaces
+            .Where(i => SymbolEqualityComparer.Default.Equals(i.OriginalDefinition, requestHandlerType))
+            .ToArray();
+
+        if (implementedHandlerInterfaces.Length == 0)
+        {
+            return false;
+        }
+
         foreach (var constructor in type.Constructors)
         {
             foreach (var param in constructor.Parameters)
             {
                 if (param.Type is INamedTypeSymbol paramType &&
                     paramType.IsGenericType &&
-                    SymbolEqualityComparer.Default.Equals(paramType.OriginalDefinition, requestHandlerType))
+                    SymbolEqualityComparer.Default.Equals(paramType.OriginalDefinition, requestHandlerType) &&
+                    implementedHandlerInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, paramType)))
                 {
                     return true;
                 }


### PR DESCRIPTION
## Problem

The `SourceGenerated` DI generator silently dropped handlers that **compose other handlers** via constructor injection, producing runtime failures:

```
No handler registered for request type 'X'.
```

### Root cause

`CqsSourceGenerator.IsDecorator` classified **any** type with an `IRequestHandler<,>` constructor parameter as a decorator and excluded it from registration:

```csharp
if (param.Type is INamedTypeSymbol paramType &&
    paramType.IsGenericType &&
    SymbolEqualityComparer.Default.Equals(paramType.OriginalDefinition, requestHandlerType))
{
    return true; // ← too broad
}
```

But injecting an `IRequestHandler<,>` is a legitimate handler pattern (a handler delegating to another handler). A **decorator** injects the *same* `IRequestHandler<TRequest, TResult>` it implements; a **composing handler** injects a *different* one. The old heuristic could not tell them apart, so every composing handler was excluded.

## Fix

`IsDecorator` now only treats a type as a decorator when the injected `IRequestHandler<T,R>` matches one of the `IRequestHandler<T,R>` interfaces the type itself implements:

- Real decorators (e.g. `PermissionRequestHandlerDecorator<TRequest, TResult>`) still match — the implemented interface and the constructor parameter use the same type parameters — so they remain excluded from handler registration.
- Composing handlers inject a *different* `IRequestHandler<T,R>` and are now correctly registered.

## Tests

- Added `HandlerInjectingAnotherHandler_IsRegisteredAndNotTreatedAsDecorator`, which fails against the old code and passes with the fix.
- Full generator test suite: **25/25 passing**.

## Versioning

Bumps `softaware.CQS.DependencyInjection.SourceGenerated` to **1.0.1** (`Version`, `FileVersion`, `AssemblyVersion`).

## Impact

Any consumer using handler-to-handler composition (constructor-injected `IRequestHandler<,>`) was affected — such handlers were missing from the generated registrations and failed at runtime. This restores parity with the previous Scrutor-based runtime discovery.
